### PR TITLE
Fix deprecation warnings: Use {$var} instead of ${var}

### DIFF
--- a/src/Suin/Sniffs/Classes/PSR4/AutoloadabilityInspectorsFactory.php
+++ b/src/Suin/Sniffs/Classes/PSR4/AutoloadabilityInspectorsFactory.php
@@ -82,7 +82,7 @@ final class AutoloadabilityInspectorsFactory
     {
         if (!\is_file($filename)) {
             throw new InvalidArgumentException(
-                "composer.json file not found: ${filename}"
+                "composer.json file not found: {$filename}"
             );
         }
     }
@@ -91,7 +91,7 @@ final class AutoloadabilityInspectorsFactory
     {
         if (!\is_readable($filename)) {
             throw new InvalidArgumentException(
-                "composer.json file is not readable: ${filename}"
+                "composer.json file is not readable: {$filename}"
             );
         }
     }


### PR DESCRIPTION
## What?
Fix PHP 8.2 deprecation warnings - pulls in https://github.com/suin/phpcs-psr4-sniff/pull/6

(cherry picked from commit 8943da7f797fb554bc145c7685c5e5b9d629e05d)

## Why?
See the description on the above PR. There are deprecation warnings in the package. Ideally these get fixed in the canonical but since the PR from Feb 2023 hasn't been merged, that doesn't seem likely any time soon.